### PR TITLE
Can't Hit Trees That Were Spawned In Editor

### DIFF
--- a/Source/HauntedHuntingJam/ForestBuilder.h
+++ b/Source/HauntedHuntingJam/ForestBuilder.h
@@ -35,6 +35,7 @@ class HAUNTEDHUNTINGJAM_API AForestBuilder : public AActor
 
 	void DeleteAllTrees();
 
+	UPROPERTY()
 	TArray<USceneComponent*> trees;
 
 	UPROPERTY(EditAnywhere)


### PR DESCRIPTION
Turns out that the array we cache the generated trees in was not being serialised, therefore, when the map was loaded this array was empty and when we attack trees we couldn't find the attacked tree in the array.

To get this member to serialised we need to add a UPROPERTY() macro to it.

fixes #35 